### PR TITLE
Create node setup scripts for convenience

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,15 @@ Follow the video [here](https://youtu.be/oxK4ykVh1EE) till 30 min. and then pip 
 ## Workspace setup procedure on Ubuntu 18.04
 1. Install ROS melodic from [here](http://wiki.ros.org/melodic/Installation/Ubuntu)
 2. install dependencies &#8594; `sudo apt install git cmake python-pip python3-pip`
-3. install python virual env using `sudo pip install virtualenv`
+3. install python virual env using `sudo python3 -m pip install virtualenv`
 4. Go to home directory `cd ~`
 5. Clone the repo ` git clone https://github.com/luxonis/Factory-calibration-DepthAI.git`
 
 ### Calibration Node setup
+For convenience, you can use the `setup_calibration_node.py` script, which executes all the commands below automatically
+```
+$ python3 setup_calibration_node.py
+```
 1. Go to python_ws directory `cd ~/Factory-calibration-DepthAI/python3_ws`
 2. Create a virtual environment using `virtualenv py3venv --python=python3`
 3. Activate the virutalenv using `source py3venv/bin/activate`
@@ -36,6 +40,12 @@ Follow the video [here](https://youtu.be/oxK4ykVh1EE) till 30 min. and then pip 
 10. Reload the usb rules `sudo udevadm control --reload-rules && udevadm trigger`
 
 ### Interbotix viperx 300s arm Node setup
+For convenience, you can use the `setup_calibration_node.py` script, which executes all the commands below automatically
+
+```
+$ python3 setup_calibration_node.py
+```
+
 1. Open a new terminal
 2. Install rosdep `sudo apt install python-rosdep2`
 3. Open interbotix_ws workspace `cd ~/Factory-calibration-DepthAI/interbotix_ws`

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Follow the video [here](https://youtu.be/oxK4ykVh1EE) till 30 min. and then pip 
 ## Workspace setup procedure on Ubuntu 18.04
 1. Install ROS melodic from [here](http://wiki.ros.org/melodic/Installation/Ubuntu)
 2. install dependencies &#8594; `sudo apt install git cmake python-pip python3-pip`
-3. install python virual env using `sudo python3 -m pip install virtualenv`
+3. install python virual env using `python3 -m pip install virtualenv`
 4. Go to home directory `cd ~`
 5. Clone the repo ` git clone https://github.com/luxonis/Factory-calibration-DepthAI.git`
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-
-opencv-contrib-python==4.4.0.46
+--extra-index-url https://www.piwheels.org/simple/
+opencv-python
+opencv-contrib-python
 requests==2.24.0
 argcomplete==1.12.1
 pygame==2.0.0

--- a/setup_arm_node.py
+++ b/setup_arm_node.py
@@ -1,0 +1,48 @@
+
+import subprocess
+import sys
+from getpass import getpass
+from pathlib import Path
+
+
+def run_command(command: str, workdir=None, sudo=False):
+    if workdir is not None:
+        print("Running command: {} inside {}".format(command, str(workdir)))
+    else:
+        print("Running command: {}".format(command))
+    if sudo:
+        command = f"echo {getpass('Please enter sudo password: ')} | sudo -S bash -c \"{command}\""
+    proc = subprocess.Popen(command, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=workdir, bufsize=1, universal_newlines=True, shell=True)
+
+    stdout = ""
+    with proc:
+        for out_c in proc.stdout:
+            if out_c is not None:
+                print(out_c, end='')
+                stdout += out_c
+
+        stderr = proc.stderr.read()
+
+    if proc.returncode != 0:
+        print(f"Command failed with exit code {proc.returncode}!", file=sys.stderr)
+        print(f"Executed: {command}", file=sys.stderr)
+        print("[STDOUT]", file=sys.stderr)
+        print(stdout, file=sys.stderr)
+        print("[STDERR]", file=sys.stderr)
+        print(stderr, file=sys.stderr)
+        raise SystemExit(proc.returncode)
+    print("Command ran successfully.")
+    return proc, stdout, stderr
+
+
+repo_root = Path(__file__).parent
+run_command("apt install -y python-rosdep2", sudo=True)
+run_command("rm -rf py3venv", workdir=repo_root / "interbotix_ws")
+run_command("virtualenv py2venv --python=python2", workdir=repo_root / "interbotix_ws")
+run_command("rosdep init", sudo=True, workdir=repo_root / "interbotix_ws")
+run_command("catkin_make", workdir=repo_root / "interbotix_ws")
+run_command("rosdep update", workdir=repo_root / "interbotix_ws")
+run_command("interbotix_ws/py2venv/bin/python -m pip install rospkg pygame")
+run_command(f"""echo "source {str(repo_root.absolute())}/interbotix_ws/devel/setup.bash" >> ~/.bashrc""")
+run_command("""cp src/interbotix_sdk/10-interbotix-udev.rules /etc/udev/rules.d""", sudo=True)
+run_command("""udevadm control --reload-rules && udevadm trigger""", sudo=True)

--- a/setup_arm_node.py
+++ b/setup_arm_node.py
@@ -38,7 +38,7 @@ def run_command(command: str, workdir=None, sudo=False):
 repo_root = Path(__file__).parent
 run_command("apt install -y python-rosdep2", sudo=True)
 run_command("rm -rf py3venv", workdir=repo_root / "interbotix_ws")
-run_command("virtualenv py2venv --python=python2", workdir=repo_root / "interbotix_ws")
+run_command(f"{sys.executable} -m virtualenv py2venv --python=python2", workdir=repo_root / "interbotix_ws")
 run_command("rosdep init", sudo=True, workdir=repo_root / "interbotix_ws")
 run_command("catkin_make", workdir=repo_root / "interbotix_ws")
 run_command("rosdep update", workdir=repo_root / "interbotix_ws")

--- a/setup_calibration_node.py
+++ b/setup_calibration_node.py
@@ -37,7 +37,7 @@ def run_command(command: str, workdir=None, sudo=False):
 repo_root = Path(__file__).parent
 run_command("rm -rf py3venv", workdir=repo_root / "python3_ws")
 run_command(f"{sys.executable} -m virtualenv py3venv --python=python3", workdir=repo_root / "python3_ws")
-run_command("apt-get install -y python3-pygame python-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsdl1.2-dev libsmpeg-dev python-numpy subversion libportmidi-dev ffmpeg libswscale-dev libavformat-dev libavcodec-dev libfreetype6-dev", sudo=True)
+run_command("apt-get install -y python-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsdl1.2-dev libsmpeg-dev python-numpy subversion libportmidi-dev ffmpeg libswscale-dev libavformat-dev libavcodec-dev libfreetype6-dev", sudo=True)
 run_command("python3_ws/py3venv/bin/python -m pip install --no-cache-dir -r requirements.txt", workdir=repo_root)
 run_command("catkin_make", workdir=repo_root / "python3_ws")
 run_command(f"""echo "source {str(repo_root.absolute())}/python3_ws/devel/setup.bash" >> ~/.bashrc""")

--- a/setup_calibration_node.py
+++ b/setup_calibration_node.py
@@ -37,7 +37,7 @@ def run_command(command: str, workdir=None, sudo=False):
 repo_root = Path(__file__).parent
 run_command("rm -rf py3venv", workdir=repo_root / "python3_ws")
 run_command(f"{sys.executable} -m virtualenv py3venv --python=python3", workdir=repo_root / "python3_ws")
-run_command("apt-get install -y python3-pygame python-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsdl1.2-dev libsmpeg-dev python-numpy subversion libportmidi-dev ffmpeg libswscale-dev libavformat-dev libavcodec-dev libfreetype6-dev")
+run_command("apt-get install -y python3-pygame python-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsdl1.2-dev libsmpeg-dev python-numpy subversion libportmidi-dev ffmpeg libswscale-dev libavformat-dev libavcodec-dev libfreetype6-dev", sudo=True)
 run_command("python3_ws/py3venv/bin/python -m pip install --no-cache-dir -r requirements.txt", workdir=repo_root)
 run_command("catkin_make", workdir=repo_root / "python3_ws")
 run_command(f"""echo "source {str(repo_root.absolute())}/python3_ws/devel/setup.bash" >> ~/.bashrc""")

--- a/setup_calibration_node.py
+++ b/setup_calibration_node.py
@@ -36,7 +36,7 @@ def run_command(command: str, workdir=None, sudo=False):
 
 repo_root = Path(__file__).parent
 run_command("rm -rf py3venv", workdir=repo_root / "python3_ws")
-run_command(f"{sys.executable} -m virtualenv py3venv --python=python3", workdir=repo_root / "python3_ws")
+run_command(f"{sys.executable} -m virtualenv py3venv --python=python3.7", workdir=repo_root / "python3_ws")
 run_command("apt-get install -y python-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsdl1.2-dev python-numpy libportmidi-dev libjpeg-dev libtiff5-dev libx11-6 libx11-dev xfonts-base xfonts-100dpi xfonts-75dpi xfonts-cyrillic fluid-soundfont-gm libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev", sudo=True)
 run_command("python3_ws/py3venv/bin/python -m pip install --no-cache-dir -r requirements.txt", workdir=repo_root)
 run_command("catkin_make", workdir=repo_root / "python3_ws")

--- a/setup_calibration_node.py
+++ b/setup_calibration_node.py
@@ -37,7 +37,7 @@ def run_command(command: str, workdir=None, sudo=False):
 repo_root = Path(__file__).parent
 run_command("rm -rf py3venv", workdir=repo_root / "python3_ws")
 run_command(f"{sys.executable} -m virtualenv py3venv --python=python3", workdir=repo_root / "python3_ws")
-run_command("apt-get install -y python-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsdl1.2-dev libsmpeg-dev python-numpy subversion libportmidi-dev ffmpeg libswscale-dev libavformat-dev libavcodec-dev libfreetype6-dev", sudo=True)
+run_command("apt-get install -y python-dev libsdl2-dev libsmpeg-dev python-numpy subversion libportmidi-dev ffmpeg libswscale-dev libavformat-dev libavcodec-dev libfreetype6-dev", sudo=True)
 run_command("python3_ws/py3venv/bin/python -m pip install --no-cache-dir -r requirements.txt", workdir=repo_root)
 run_command("catkin_make", workdir=repo_root / "python3_ws")
 run_command(f"""echo "source {str(repo_root.absolute())}/python3_ws/devel/setup.bash" >> ~/.bashrc""")

--- a/setup_calibration_node.py
+++ b/setup_calibration_node.py
@@ -37,7 +37,7 @@ def run_command(command: str, workdir=None, sudo=False):
 repo_root = Path(__file__).parent
 run_command("rm -rf py3venv", workdir=repo_root / "python3_ws")
 run_command(f"{sys.executable} -m virtualenv py3venv --python=python3", workdir=repo_root / "python3_ws")
-run_command("apt-get install python-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsdl1.2-dev python-numpy libportmidi-dev libjpeg-dev libtiff5-dev libx11-6 libx11-dev xfonts-base xfonts-100dpi xfonts-75dpi xfonts-cyrillic fluid-soundfont-gm libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev", sudo=True)
+run_command("apt-get install -y python-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsdl1.2-dev python-numpy libportmidi-dev libjpeg-dev libtiff5-dev libx11-6 libx11-dev xfonts-base xfonts-100dpi xfonts-75dpi xfonts-cyrillic fluid-soundfont-gm libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev", sudo=True)
 run_command("python3_ws/py3venv/bin/python -m pip install --no-cache-dir -r requirements.txt", workdir=repo_root)
 run_command("catkin_make", workdir=repo_root / "python3_ws")
 run_command(f"""echo "source {str(repo_root.absolute())}/python3_ws/devel/setup.bash" >> ~/.bashrc""")

--- a/setup_calibration_node.py
+++ b/setup_calibration_node.py
@@ -37,6 +37,7 @@ def run_command(command: str, workdir=None, sudo=False):
 repo_root = Path(__file__).parent
 run_command("rm -rf py3venv", workdir=repo_root / "python3_ws")
 run_command(f"{sys.executable} -m virtualenv py3venv --python=python3", workdir=repo_root / "python3_ws")
+run_command("apt-get install -y python3-pygame python-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsdl1.2-dev libsmpeg-dev python-numpy subversion libportmidi-dev ffmpeg libswscale-dev libavformat-dev libavcodec-dev libfreetype6-dev")
 run_command("python3_ws/py3venv/bin/python -m pip install -r requirements.txt", workdir=repo_root)
 run_command("catkin_make", workdir=repo_root / "python3_ws")
 run_command(f"""echo "source {str(repo_root.absolute())}/python3_ws/devel/setup.bash" >> ~/.bashrc""")

--- a/setup_calibration_node.py
+++ b/setup_calibration_node.py
@@ -36,7 +36,7 @@ def run_command(command: str, workdir=None, sudo=False):
 
 repo_root = Path(__file__).parent
 run_command("rm -rf py3venv", workdir=repo_root / "python3_ws")
-run_command("virtualenv py3venv --python=python3", workdir=repo_root / "python3_ws")
+run_command(f"{sys.executable} -m virtualenv py3venv --python=python3", workdir=repo_root / "python3_ws")
 run_command("python3_ws/py3venv/bin/python -m pip install -r requirements.txt", workdir=repo_root)
 run_command("catkin_make", workdir=repo_root / "python3_ws")
 run_command(f"""echo "source {str(repo_root.absolute())}/python3_ws/devel/setup.bash" >> ~/.bashrc""")

--- a/setup_calibration_node.py
+++ b/setup_calibration_node.py
@@ -38,7 +38,7 @@ repo_root = Path(__file__).parent
 run_command("rm -rf py3venv", workdir=repo_root / "python3_ws")
 run_command(f"{sys.executable} -m virtualenv py3venv --python=python3", workdir=repo_root / "python3_ws")
 run_command("apt-get install -y python3-pygame python-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsdl1.2-dev libsmpeg-dev python-numpy subversion libportmidi-dev ffmpeg libswscale-dev libavformat-dev libavcodec-dev libfreetype6-dev")
-run_command("python3_ws/py3venv/bin/python -m pip install -r requirements.txt", workdir=repo_root)
+run_command("python3_ws/py3venv/bin/python -m pip install --no-cache-dir -r requirements.txt", workdir=repo_root)
 run_command("catkin_make", workdir=repo_root / "python3_ws")
 run_command(f"""echo "source {str(repo_root.absolute())}/python3_ws/devel/setup.bash" >> ~/.bashrc""")
 run_command("""echo 'SUBSYSTEM=="usb", ATTRS{idVendor}=="03e7", MODE="0666"' | tee /etc/udev/rules.d/80-movidius.rules""", sudo=True)

--- a/setup_calibration_node.py
+++ b/setup_calibration_node.py
@@ -1,0 +1,44 @@
+import subprocess
+import sys
+from getpass import getpass
+from pathlib import Path
+
+
+def run_command(command: str, workdir=None, sudo=False):
+    if workdir is not None:
+        print("Running command: {} inside {}".format(command, str(workdir)))
+    else:
+        print("Running command: {}".format(command))
+    if sudo:
+        command = f"echo {getpass('Please enter sudo password: ')} | sudo -S bash -c \"{command}\""
+    proc = subprocess.Popen(command, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=workdir, bufsize=1, universal_newlines=True, shell=True)
+
+    stdout = ""
+    with proc:
+        for out_c in proc.stdout:
+            if out_c is not None:
+                print(out_c, end='')
+                stdout += out_c
+
+        stderr = proc.stderr.read()
+
+    if proc.returncode != 0:
+        print(f"Command failed with exit code {proc.returncode}!", file=sys.stderr)
+        print(f"Executed: {command}", file=sys.stderr)
+        print("[STDOUT]", file=sys.stderr)
+        print(stdout, file=sys.stderr)
+        print("[STDERR]", file=sys.stderr)
+        print(stderr, file=sys.stderr)
+        raise SystemExit(proc.returncode)
+    print("Command ran successfully.")
+    return proc, stdout, stderr
+
+
+repo_root = Path(__file__).parent
+run_command("rm -rf py3venv", workdir=repo_root / "python3_ws")
+run_command("virtualenv py3venv --python=python3", workdir=repo_root / "python3_ws")
+run_command("python3_ws/py3venv/bin/python -m pip install -r requirements.txt", workdir=repo_root)
+run_command("catkin_make", workdir=repo_root / "python3_ws")
+run_command(f"""echo "source {str(repo_root.absolute())}/python3_ws/devel/setup.bash" >> ~/.bashrc""")
+run_command("""echo 'SUBSYSTEM=="usb", ATTRS{idVendor}=="03e7", MODE="0666"' | tee /etc/udev/rules.d/80-movidius.rules""", sudo=True)
+run_command("""udevadm control --reload-rules && udevadm trigger""", sudo=True)

--- a/setup_calibration_node.py
+++ b/setup_calibration_node.py
@@ -37,7 +37,7 @@ def run_command(command: str, workdir=None, sudo=False):
 repo_root = Path(__file__).parent
 run_command("rm -rf py3venv", workdir=repo_root / "python3_ws")
 run_command(f"{sys.executable} -m virtualenv py3venv --python=python3", workdir=repo_root / "python3_ws")
-run_command("apt-get install python-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsdl1.2-dev python-numpy libportmidi-dev libjpeg-dev libtiff5-dev libx11-6 libx11-dev xfonts-base xfonts-100dpi xfonts-75dpi xfonts-cyrillic fluid-soundfont-gm timgm6mb-soundfront libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev", sudo=True)
+run_command("apt-get install python-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsdl1.2-dev python-numpy libportmidi-dev libjpeg-dev libtiff5-dev libx11-6 libx11-dev xfonts-base xfonts-100dpi xfonts-75dpi xfonts-cyrillic fluid-soundfont-gm libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev", sudo=True)
 run_command("python3_ws/py3venv/bin/python -m pip install --no-cache-dir -r requirements.txt", workdir=repo_root)
 run_command("catkin_make", workdir=repo_root / "python3_ws")
 run_command(f"""echo "source {str(repo_root.absolute())}/python3_ws/devel/setup.bash" >> ~/.bashrc""")

--- a/setup_calibration_node.py
+++ b/setup_calibration_node.py
@@ -37,7 +37,7 @@ def run_command(command: str, workdir=None, sudo=False):
 repo_root = Path(__file__).parent
 run_command("rm -rf py3venv", workdir=repo_root / "python3_ws")
 run_command(f"{sys.executable} -m virtualenv py3venv --python=python3", workdir=repo_root / "python3_ws")
-run_command("apt-get install -y python-dev libsdl2-dev libsmpeg-dev python-numpy subversion libportmidi-dev ffmpeg libswscale-dev libavformat-dev libavcodec-dev libfreetype6-dev", sudo=True)
+run_command("apt-get install python-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsdl1.2-dev python-numpy libportmidi-dev libjpeg-dev libtiff5-dev libx11-6 libx11-dev xfonts-base xfonts-100dpi xfonts-75dpi xfonts-cyrillic fluid-soundfont-gm musescore-soundfont-gm libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev", sudo=True)
 run_command("python3_ws/py3venv/bin/python -m pip install --no-cache-dir -r requirements.txt", workdir=repo_root)
 run_command("catkin_make", workdir=repo_root / "python3_ws")
 run_command(f"""echo "source {str(repo_root.absolute())}/python3_ws/devel/setup.bash" >> ~/.bashrc""")

--- a/setup_calibration_node.py
+++ b/setup_calibration_node.py
@@ -37,7 +37,7 @@ def run_command(command: str, workdir=None, sudo=False):
 repo_root = Path(__file__).parent
 run_command("rm -rf py3venv", workdir=repo_root / "python3_ws")
 run_command(f"{sys.executable} -m virtualenv py3venv --python=python3", workdir=repo_root / "python3_ws")
-run_command("apt-get install python-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsdl1.2-dev python-numpy libportmidi-dev libjpeg-dev libtiff5-dev libx11-6 libx11-dev xfonts-base xfonts-100dpi xfonts-75dpi xfonts-cyrillic fluid-soundfont-gm musescore-soundfont-gm libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev", sudo=True)
+run_command("apt-get install python-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsdl1.2-dev python-numpy libportmidi-dev libjpeg-dev libtiff5-dev libx11-6 libx11-dev xfonts-base xfonts-100dpi xfonts-75dpi xfonts-cyrillic fluid-soundfont-gm timgm6mb-soundfront libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev", sudo=True)
 run_command("python3_ws/py3venv/bin/python -m pip install --no-cache-dir -r requirements.txt", workdir=repo_root)
 run_command("catkin_make", workdir=repo_root / "python3_ws")
 run_command(f"""echo "source {str(repo_root.absolute())}/python3_ws/devel/setup.bash" >> ~/.bashrc""")


### PR DESCRIPTION
This PR adds two convenience scripts, one for arm node setuip and another for calibration node setup.

TODO:
- Test calibration node setup on RPi with Ubuntu Bionic (@VanDavv)
- Test arm node setup (@saching13 - could you test it on your end? I don't have the calibration arm on my end so I don't know if I'll be able to test this correctly)